### PR TITLE
rel4.5.4 workaround fix for loop in content pull

### DIFF
--- a/CLI/package.json
+++ b/CLI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wchtools-cli",
   "description": "Command line tools for Acoustic Content",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "keywords": [
     "cli"
   ],

--- a/authoring-api/baseHelper.js
+++ b/authoring-api/baseHelper.js
@@ -1264,7 +1264,7 @@ class BaseHelper {
         const chunkSize = listInfo.length;
         const limit = options.getRelevantOption(context, opts, "limit", helper.getArtifactName());
         //test to see if we got less than the full chunk size
-        if ((this._restApi.useNextLinks(context, undefined, opts) && !opts.nextURI) || (chunkSize === 0 || chunkSize < limit)) {
+        if ((this._restApi.useNextLinks(context, undefined, opts) && !opts.nextURI) || (chunkSize === 0 || chunkSize < limit) || (opts.prevNextURI === opts.nextURI)) {
             //resolve the deferred with the allItems array
             deferred.resolve(allItems);
         } else {

--- a/authoring-api/lib/BaseREST.js
+++ b/authoring-api/lib/BaseREST.js
@@ -430,6 +430,7 @@ class BaseREST {
                         // If next links is enabled and the response contains a next link, set it in the opts.
                         // Otherwise, ensure that there is no nextURI value in the opts.
                         if (restObject.useNextLinks(context, undefined, opts) && opts && body.next) {
+                            opts.prevNextURI = opts.nextURI;
                             opts.nextURI = body.next;
                         } else if (opts && opts.nextURI) {
                             delete opts.nextURI;

--- a/authoring-api/package.json
+++ b/authoring-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wchtools-api",
   "description": "Tools API for Acoustic Content",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "keywords": [
     "api",
     "tools"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prod-tools",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "author": "Acoustic, L.P.",
   "license": "Apache-2.0",
   "bugs": {


### PR DESCRIPTION
This commit contains workaround fix for cases when `pull` of content items using `-I` creates an infinite loop.
For example: `wchtools pull -A -I -v`